### PR TITLE
Added support for Follow Plugin

### DIFF
--- a/config/locales/server.de.yml
+++ b/config/locales/server.de.yml
@@ -48,3 +48,16 @@ de:
                 🔗 <a href="%{user_url}">@%{username}</a> hat dich in
                 <a href="%{post_url}">%{topic}</a> <b>verlinkt</b>
                 <pre>%{post_excerpt}</pre>
+      watching_first_post: |-
+                💬 <a href="%{user_url}">@%{username}</a> hat in <a href="%{post_url}">%{topic}</a>
+                <b>geantwortet</b>
+                <pre>%{post_excerpt}</pre>
+      # Discourse Follow Plugin
+      following_replied: |-
+                ↩️👥 <a href="%{user_url}">@%{username}</a> hat in <a href="%{post_url}">%{topic}</a>
+                <b>geantwortet</b>
+                <pre>%{post_excerpt}</pre>
+      following_posted: |-
+                💬👥 <a href="%{user_url}">@%{username}</a> hat in <a href="%{post_url}">%{topic}</a>
+                <b>geantwortet</b>
+                <pre>%{post_excerpt}</pre>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -56,7 +56,12 @@ en:
 
                 <pre>%{post_excerpt}</pre>
       following_replied: |-
-                👥 <a href="%{user_url}">@%{username}</a> <b>posted</b>
+                ↩️ <a href="%{user_url}">@%{username}</a> <b>replied</b> to you
                 in <a href="%{post_url}">%{topic}</a>
-                
+
+                <pre>%{post_excerpt}</pre>
+      following_posted: |-
+                💬 <a href="%{user_url}">@%{username}</a> <b>posted</b>
+                in <a href="%{post_url}">%{topic}</a>
+
                 <pre>%{post_excerpt}</pre>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -58,3 +58,5 @@ en:
       following_replied: |-
                 👥 <a href="%{user_url}">@%{username}</a> <b>posted</b>
                 in <a href="%{post_url}">%{topic}</a>
+                
+                <pre>%{post_excerpt}</pre>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -55,3 +55,6 @@ en:
                 from <a href="%{post_url}">%{topic}</a>
 
                 <pre>%{post_excerpt}</pre>
+      following_replied: |-
+                👥 <a href="%{user_url}">@%{username}</a> <b>posted</b>
+                in <a href="%{post_url}">%{topic}</a>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -55,13 +55,19 @@ en:
                 from <a href="%{post_url}">%{topic}</a>
 
                 <pre>%{post_excerpt}</pre>
+      watching_first_post: |-
+                💬 <a href="%{user_url}">@%{username}</a> <b>posted</b>
+                in <a href="%{post_url}">%{topic}</a>
+
+                <pre>%{post_excerpt}</pre>
+      # Discourse Follow Plugin
       following_replied: |-
-                ↩️ <a href="%{user_url}">@%{username}</a> <b>replied</b> to you
+                ↩️👥 <a href="%{user_url}">@%{username}</a> <b>replied</b>
                 in <a href="%{post_url}">%{topic}</a>
 
                 <pre>%{post_excerpt}</pre>
       following_posted: |-
-                💬 <a href="%{user_url}">@%{username}</a> <b>posted</b>
+                💬👥 <a href="%{user_url}">@%{username}</a> <b>posted</b>
                 in <a href="%{post_url}">%{topic}</a>
 
                 <pre>%{post_excerpt}</pre>

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -55,8 +55,20 @@ es:
                 desde <a href="%{post_url}">%{topic}</a>
 
                 <pre>%{post_excerpt}</pre>
+      
+      watching_first_post: |-
+                💬 <a href="%{user_url}">@%{username}</a> ha <b>publicado</b>
+                en <a href="%{post_url}">%{topic}</a>
+
+                <pre>%{post_excerpt}</pre>
+      # Discourse Follow Plugin
       following_replied: |-
-                👥 <a href="%{user_url}">@%{username}</a> ha <b>publicado</b>
+                ↩️👥 <a href="%{user_url}">@%{username}</a> ha <b>respondido</b>
+                en <a href="%{post_url}">%{topic}</a>
+
+                <pre>%{post_excerpt}</pre>
+      following_posted: |-
+                💬👥 <a href="%{user_url}">@%{username}</a> <b>publicó</b>
                 en <a href="%{post_url}">%{topic}</a>
 
                 <pre>%{post_excerpt}</pre>

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -55,3 +55,6 @@ es:
                 desde <a href="%{post_url}">%{topic}</a>
 
                 <pre>%{post_excerpt}</pre>
+      following_replied: |-
+                👥 <a href="%{user_url}">@%{username}</a> ha <b>publicado</b>
+                en <a href="%{post_url}">%{topic}</a>

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -58,3 +58,5 @@ es:
       following_replied: |-
                 👥 <a href="%{user_url}">@%{username}</a> ha <b>publicado</b>
                 en <a href="%{post_url}">%{topic}</a>
+
+                <pre>%{post_excerpt}</pre>

--- a/config/locales/server.it.yml
+++ b/config/locales/server.it.yml
@@ -55,3 +55,19 @@ it:
                 da <a href="%{post_url}">%{topic}</a>
 
                 <pre>%{post_excerpt}</pre>
+      watching_first_post: |-
+                💬 <a href="%{user_url}">@%{username}</a> <b>ha postato</b>
+                in <a href="%{post_url}">%{topic}</a>
+
+                <pre>%{post_excerpt}</pre>
+      # Discourse Follow Plugin
+      following_replied: |-
+                ↩️👥 <a href="%{user_url}">@%{username}</a> <b>ha risposto</b>
+                in <a href="%{post_url}">%{topic}</a>
+
+                <pre>%{post_excerpt}</pre>
+      following_posted: |-
+                💬👥 <a href="%{user_url}">@%{username}</a> <b>ha postato</b>
+                in <a href="%{post_url}">%{topic}</a>
+
+                <pre>%{post_excerpt}</pre>


### PR DESCRIPTION
In our forum, we make usage of the Discourse Follow Plugin (https://meta.discourse.org/t/follow-plugin/110579) and Telegram Notifications one.
However, this plugin does not support those kinds of notifications, and our users were getting this error all the time:
![image](https://user-images.githubusercontent.com/19251112/72206852-cbf63000-3492-11ea-92a1-9f374606571b.png)

This PR aims to solve it, by providing a localized string to place messages at.