### PR TITLE
SECURITY: fix webhook secret validation (and requires_plugin guard)

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -32,7 +32,7 @@ after_initialize do
   end
 
   class DiscourseTelegramNotifications::TelegramController < ::ApplicationController
-    requires_plugin DiscourseTelegramNotifications::PLUGIN_NAME
+    requires_plugin "discourse-telegram-notifications"
 
     skip_before_action :check_xhr, :preload_json, :verify_authenticity_token, :redirect_to_login_if_required
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -41,10 +41,10 @@ after_initialize do
         render status: 404
       end
 
-      if not (defined? params['key'] && (params['key'] == SiteSetting.telegram_secret))
+      secret = SiteSetting.telegram_secret
+      if secret.blank? || !ActiveSupport::SecurityUtils.secure_compare(params[:key].to_s, secret)
         Rails.logger.error("Telegram hook called with incorrect key")
-        render status: 403
-        return
+        return render(body: nil, status: 403)
       end
 
       # If it's a new message (telegram also sends hooks for other reasons that we don't care about)

--- a/spec/requests/telegram_hook_auth_spec.rb
+++ b/spec/requests/telegram_hook_auth_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Telegram webhook authentication", type: :request do
+  before do
+    SiteSetting.telegram_notifications_enabled = true
+    SiteSetting.telegram_access_token = "test-token"
+    SiteSetting.telegram_secret = "correct-secret"
+  end
+
+  it "rejects a request whose key does not match the secret" do
+    post "/telegram/hook/wrong-secret", params: {}, as: :json
+    expect(response.status).to eq(403)
+  end
+
+  it "rejects every request while no secret is configured" do
+    SiteSetting.telegram_secret = ""
+    post "/telegram/hook/anything", params: {}, as: :json
+    expect(response.status).to eq(403)
+  end
+
+  it "accepts a request whose key matches the secret" do
+    post "/telegram/hook/correct-secret", params: {}, as: :json
+    expect(response.status).to eq(200)
+    expect(response.parsed_body["success"]).to eq(true)
+  end
+end


### PR DESCRIPTION
**In short:** the security check that protects the webhook never worked, so anyone could call it. This fixes the check, repairs the related `requires_plugin` guard, and adds a test.

### What was wrong
The code that checks the secret key was:
```ruby
if not (defined? params['key'] && (params['key'] == SiteSetting.telegram_secret))
```
In Ruby, `defined?` is read *before* the `&&`. So this actually means `not defined?(...)`. `defined?` almost always returns a value (the text `"expression"`), which counts as "true". So `not true` is always `false`, and the check is **never** triggered. Any key is accepted.

### Why it matters
`/telegram/hook/:key` has no login and no CSRF protection. With the check broken, anyone who sends a fake Telegram message to this URL can make the bot send messages, or create and like posts as any user who set a chat ID.

### The fix
Compare the key from the URL with the saved secret using `ActiveSupport::SecurityUtils.secure_compare` (a timing-safe compare). Also reject the request when no secret is set yet.

`secure_compare` returns `false` (it does not crash) when the two values have different lengths, so a wrong key gives a clean `403`.

### Second fix in this PR: `requires_plugin`
While adding a test I found a related bug. The controller had:
```ruby
requires_plugin DiscourseTelegramNotifications::PLUGIN_NAME   # "discourse_telegram_notifications"
```
But `Discourse.plugins_by_name` is keyed by the metadata name and the directory name — both `discourse-telegram-notifications` (hyphens), not the underscored `PLUGIN_NAME`. So the lookup missed:
- in **production** the guard silently did nothing (`Rails.logger.warn "Required plugin not found"`);
- in the **test env** it raised `Required plugin not found`, which blocks any request spec.

Fixed by passing the real plugin name: `requires_plugin "discourse-telegram-notifications"`.

I put both fixes in one PR because they are the same subject — making the webhook endpoint's request guards actually work — and the test needs the second fix to run.

### Test
Added `spec/requests/telegram_hook_auth_spec.rb`:
- wrong key → `403`
- no secret configured → `403`
- correct key → `200`

### Note for reviewers
This PR and the "double render on disabled" PR (#36) both edit the same `hook` method, so whichever merges first will need a trivial rebase of the other.
