### PR TITLE
FIX: hook double-renders (500) when notifications disabled

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -38,7 +38,7 @@ after_initialize do
 
     def hook
       if not SiteSetting.telegram_notifications_enabled
-        render status: 404
+        return render(body: nil, status: 404)
       end
 
       if not (defined? params['key'] && (params['key'] == SiteSetting.telegram_secret))


### PR DESCRIPTION
**In short:** when the plugin is turned off, the webhook can crash with a 500 error. This makes it return a clean 404 instead.

### What was wrong
```ruby
if not SiteSetting.telegram_notifications_enabled
  render status: 404
end
```
There is no `return`, so the code keeps running after `render`. At the end of the method it calls `render` a second time. Rails does not allow two renders in one request, so it raises `DoubleRenderError` (HTTP 500). Also, `render status: 404` with no body can fail on its own.

### The fix
`return render(body: nil, status: 404)` — stop right away and send an empty 404.

### Note for reviewers (interaction with `requires_plugin`)
In theory `requires_plugin` should already return 404 when the plugin is disabled, before this method runs. But the controller currently passes the wrong plugin name to `requires_plugin`, so that guard silently does nothing in production (see #35, which fixes the name). That is why this in-body check is the effective "disabled" guard today, and why the crash is reachable.

Once #35 is merged, `requires_plugin` will return 404 for disabled requests before the body runs, making this in-body check redundant. It is still worth keeping as clear, correct defense-in-depth (and it stops the 500 on branches/older versions where the name is not yet fixed). If you'd rather remove the now-redundant block instead, I can do that.

This PR and #35 both edit the same `hook` method, so whichever merges first needs a trivial rebase of the other.

_Draft: checked with `ruby -c`._
