### PR TITLE
FIX: add missing event_reminder/event_invitation message templates

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -72,3 +72,14 @@ en:
                 in <a href="%{post_url}">%{topic}</a>
 
                 <pre>%{post_excerpt}</pre>
+      # Discourse Calendar Plugin
+      event_reminder: |-
+                📅 <b>Event reminder</b>
+                in <a href="%{post_url}">%{topic}</a>
+
+                <pre>%{post_excerpt}</pre>
+      event_invitation: |-
+                📅 <a href="%{user_url}">@%{username}</a> <b>invited you to an event</b>
+                in <a href="%{post_url}">%{topic}</a>
+
+                <pre>%{post_excerpt}</pre>


### PR DESCRIPTION
**In short:** two notification types are ON by default but have no message text, so users can get a "translation missing" message. This adds the missing text.

### What was wrong
`config/settings.yml` turns on `event_reminder` and `event_invitation` by default (these come from the Discourse Calendar plugin). But no language file has the message text for them. When such a notification is sent, the user receives a raw string like:

`translation missing: en.discourse_telegram_notifications.message.event_reminder`

### The fix
Add English text for both keys in `config/locales/server.en.yml`. English is the fallback language, so this fixes every language. Translators can add their own wording later.

### Verification (which types actually reach this plugin)
I traced how these notifications are created, to be sure the templates are used and safe:

- **`event_reminder`** — created in discourse-calendar `jobs/regular/discourse_post_event/send_reminder.rb`, which calls `PostAlerter.new(event.post).create_notification_alert(...)`. Core `create_notification_alert` triggers the `:post_notification_alert` event this plugin listens to. **So this type does reach the plugin and needs the template.**
- **`event_invitation`** — created in discourse-calendar `app/models/discourse_post_event/event.rb` via `user.notifications.consolidate_or_create!`, which does **not** go through `PostAlerter` and does **not** trigger `:post_notification_alert`. So today this type never reaches the plugin. I kept its template anyway as harmless forward-coverage (it is in the default settings list, and the template costs nothing), but I'm happy to drop `event_invitation` from both the template and the default list if you'd prefer no dead entry.

### Safety of the interpolations
Core `create_notification_alert` only fires when `post.url` is present and always sets `username: username || post.username`, so `payload[:username]` is never `nil` when the send job runs. The `event_reminder` template also avoids `@username` entirely (a reminder is not from a person).

_Draft: YAML validated with `YAML.load_file`._
