### PR TITLE
FIX: add missing 'error-unknown-action' locale key

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -18,7 +18,7 @@ en:
     unlike-failed: "Unliking that post failed"
     unlike-success: "Unlike successful"
     error-unknown-action: "❌ Unknown action"
-    reply-error: "❌ An error occured while processing your reply"
+    reply-error: "❌ An error occurred while processing your reply"
     reply-failed: "❌ Reply failed: \n\n %{errors}"
     reply-success: "✅ Reply successful - view it <a href='%{post_url}'>here</a>"
     message:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -17,6 +17,7 @@ en:
     like-success: "Like successful"
     unlike-failed: "Unliking that post failed"
     unlike-success: "Unlike successful"
+    error-unknown-action: "❌ Unknown action"
     reply-error: "❌ An error occured while processing your reply"
     reply-failed: "❌ Reply failed: \n\n %{errors}"
     reply-success: "✅ Reply successful - view it <a href='%{post_url}'>here</a>"


### PR DESCRIPTION
**In short:** one more missing translation key. This adds it.

### What was wrong
The code uses `error-unknown-action` as a default message for an unknown button action:
```ruby
I18n.t("discourse_telegram_notifications.error-unknown-action")
```
No language file has this key, so it would show "translation missing".

### The fix
Add `error-unknown-action` to `config/locales/server.en.yml`. English is the fallback, so this covers all languages.

_Draft: YAML checked with `YAML.load_file`._
