### PR TITLE
FIX: guard nil user/post in callback_query handler (stops webhook retry storm)

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -122,12 +122,18 @@ after_initialize do
         DiscourseTelegramNotifications::TelegramNotifier.sendMessage(message)
       elsif params.key?('callback_query')
         chat_id = params['callback_query']['message']['chat']['id']
-        user_id = UserCustomField.where(name: "telegram_chat_id", value: chat_id).first.user_id
-        user = User.find(user_id)
+        user_custom_field = UserCustomField.find_by(name: "telegram_chat_id", value: chat_id)
+        user = user_custom_field && User.find_by(id: user_custom_field.user_id)
 
-        data = params['callback_query']['data'].split(":")
+        data = params['callback_query']['data'].to_s.split(":")
+        post = Post.find_by(id: data[1])
 
-        post = Post.find(data[1])
+        # Ignore callbacks from unknown chats or for posts that no longer exist
+        # (e.g. stale inline buttons); acknowledge so Telegram stops retrying.
+        if user.nil? || post.nil?
+          DiscourseTelegramNotifications::TelegramNotifier.answerCallback(params['callback_query']['id'], "")
+          return render json: { success: true }
+        end
 
         string = I18n.t("discourse_telegram_notifications.error-unknown-action")
 


### PR DESCRIPTION
**In short:** pressing a like/unlike button could crash the webhook with a 500 error. When that happens, Telegram sends the same request again and again. This handles the bad cases safely.

### What was wrong
```ruby
user_id = UserCustomField.where(...).first.user_id
user = User.find(user_id)
...
post = Post.find(data[1])
```
- If the chat is not linked to a user, `.first` is `nil`, and calling `.user_id` on `nil` crashes.
- If the post was deleted, `Post.find` raises an error.

Either way the method never returns success. Telegram treats a non-200 answer as a failure, so it keeps re-sending the same update (a loop).

### The fix
Use `find_by`, which returns `nil` instead of crashing. If the user or post is missing, answer the button (this clears the loading spinner in Telegram) and return `200`. Ignoring an old or fake button is the correct behavior.

No new translation text is added (kept separate from the `error-unknown-action` fix).

### How to verify manually
Press an old like/unlike button whose post has since been deleted (or from a chat with no linked user). Before: 500 error and repeated retries from Telegram. After: the button is acknowledged and the request returns 200.

_Draft: checked with `ruby -c`._
