### PR TITLE
FIX: skip send job when the post cannot be resolved (nil post crash)

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -215,6 +215,10 @@ after_initialize do
 
           post = Post.where(post_number: payload[:post_number], topic_id: payload[:topic_id]).first
 
+          # No resolvable post (e.g. deleted, or a notification type without a
+          # matching post): nothing to link/like, so skip rather than crash on post.id.
+          return if post.nil?
+
           message_text = I18n.t(
               "discourse_telegram_notifications.message.#{Notification.types[payload[:notification_type]]}",
               site_title: CGI::escapeHTML(SiteSetting.title),


### PR DESCRIPTION
**In short:** the background job could crash when the post is missing. This skips the notification instead.

### What was wrong
```ruby
post = Post.where(...).first
...
generateReplyMarkup(post, user)   # this calls post.id
```
`post` can be `nil` (the post was deleted, or this notification type has no matching post). Then `post.id` crashes, the job fails, and it retries.

### The fix
`return if post.nil?` right after looking it up. If there is no post, there is nothing to link or "like", so we just skip this notification.

### How to verify manually
Enqueue a notification whose post has been deleted. Before: the Sidekiq job raises `NoMethodError` and retries. After: the job returns quietly and sends nothing.

_Draft: checked with `ruby -c`._
