### PR TITLE
FIX: handle non-text Telegram replies without erroring

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -83,28 +83,34 @@ after_initialize do
           end
 
           if found_post
+            reply_text = params['message']['text']
 
-            new_post = {
-              raw: params['message']['text'],
-              topic_id: reply_to.topic_id,
-              reply_to_post_number: reply_to.post_number,
-            }
-
-            manager = NewPostManager.new(user, new_post)
-            result = manager.perform
-
-            if result.errors.any?
-              errors = result.errors.full_messages.join("\n")
-
-              message_text = I18n.t(
-                "discourse_telegram_notifications.reply-failed",
-                errors: errors
-              )
+            if reply_text.blank?
+              # Non-text reply (photo, sticker, voice, ...): nothing to post as raw.
+              message_text = I18n.t("discourse_telegram_notifications.reply-error")
             else
-              message_text = I18n.t(
-                "discourse_telegram_notifications.reply-success",
-                post_url: result.post.full_url
-              )
+              new_post = {
+                raw: reply_text,
+                topic_id: reply_to.topic_id,
+                reply_to_post_number: reply_to.post_number,
+              }
+
+              manager = NewPostManager.new(user, new_post)
+              result = manager.perform
+
+              if result.errors.any?
+                errors = result.errors.full_messages.join("\n")
+
+                message_text = I18n.t(
+                  "discourse_telegram_notifications.reply-failed",
+                  errors: errors
+                )
+              else
+                message_text = I18n.t(
+                  "discourse_telegram_notifications.reply-success",
+                  post_url: result.post.full_url
+                )
+              end
             end
           else
             message_text = I18n.t("discourse_telegram_notifications.reply-error")


### PR DESCRIPTION
**In short:** replying to a notification with a photo or sticker (no text) could crash. This replies with an error message instead.

### What was wrong
```ruby
new_post = { raw: params['message']['text'], ... }
```
If the reply has no text (a photo, sticker, voice message, etc.), `text` is `nil`. That empty value becomes the post body, and creating a post with no text fails.

### The fix
Read the reply text first. If it is empty, send back the existing `reply-error` message instead of trying to create a post. Normal text replies still work as before.

No new translation text is added (uses the existing `reply-error`).

### How to verify manually
Reply to a bot notification with a photo/sticker (no caption). Before: the reply crashes while creating the post. After: the bot answers with the "error while processing your reply" message and does not crash.

_Draft: checked with `ruby -c`._
