### PR TITLE
FIX: add HTTP timeouts and rescue network errors in TelegramNotifier

### DIFF
--- a/services/discourse_telegram_notifications/telegram-notifier.rb
+++ b/services/discourse_telegram_notifications/telegram-notifier.rb
@@ -31,6 +31,8 @@ module DiscourseTelegramNotifications
     def self.doRequest(methodName, message)
       http = Net::HTTP.new("api.telegram.org", 443)
       http.use_ssl = true
+      http.open_timeout = 5
+      http.read_timeout = 10
 
       access_token = SiteSetting.telegram_access_token
 
@@ -38,9 +40,13 @@ module DiscourseTelegramNotifications
 
       req = Net::HTTP::Post.new(uri, 'Content-Type' =>'application/json')
       req.body = message.to_json
-      response = http.request(req)
-
-      responseData = JSON.parse(response.body)
+      begin
+        response = http.request(req)
+        responseData = JSON.parse(response.body)
+      rescue Net::OpenTimeout, Net::ReadTimeout, Timeout::Error, OpenSSL::SSL::SSLError, EOFError, SocketError, SystemCallError, JSON::ParserError => e
+        Rails.logger.error("Telegram request to #{methodName} failed: #{e.class}: #{e.message}")
+        return false
+      end
 
       if not responseData['ok'] == true
         Rails.logger.error("Failed to send Telegram message. Message data= "+req.body.to_json+ " response="+response.body.to_json)


### PR DESCRIPTION
**In short:** calls to Telegram had no time limit and could crash on network errors. This adds timeouts and handles those errors.

### What was wrong
The HTTP call to Telegram had no timeout:
```ruby
http = Net::HTTP.new("api.telegram.org", 443)
...
response = http.request(req)
```
The message and button paths call this **while handling the webhook request**. If Telegram is slow or down, the web worker waits for a very long time. Any network or parsing error also crashes the caller (a 500 error, or a failed job).

### The fix
- Set `open_timeout = 5` and `read_timeout = 10` seconds.
- Wrap the request in a rescue for the errors an HTTPS call can raise: timeouts, `OpenSSL::SSL::SSLError` (TLS problems), `EOFError` (dropped connection), `SocketError`, `SystemCallError` (for example, connection refused or reset), and `JSON::ParserError`. On error, log it and return `false` — the value the callers already treat as "failed".

I listed the errors on purpose instead of catching everything, so real programming mistakes still show up.

### How to verify manually
Point the bot token at an unreachable host, or block `api.telegram.org`. Before: the request hangs or 500s. After: it fails within ~10s, logs one line, and returns `false` (callers already handle this).

### Note for reviewers
This PR and #44 both edit `telegram-notifier.rb`, but different regions (`doRequest` here, a new `deleteWebhook` method in #44), so they should merge without conflict.

_Draft: checked with `ruby -c`._
