### PR TITLE
FIX: delete Telegram webhook when the plugin is disabled

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -247,12 +247,12 @@ after_initialize do
 
       class SetupTelegramWebhook < ::Jobs::Base
         def execute(args)
-          return if !SiteSetting.telegram_notifications_enabled?
-
-          SiteSetting.telegram_secret = SecureRandom.hex
-
-          DiscourseTelegramNotifications::TelegramNotifier.setupWebhook(SiteSetting.telegram_secret)
-
+          if SiteSetting.telegram_notifications_enabled?
+            SiteSetting.telegram_secret = SecureRandom.hex
+            DiscourseTelegramNotifications::TelegramNotifier.setupWebhook(SiteSetting.telegram_secret)
+          else
+            DiscourseTelegramNotifications::TelegramNotifier.deleteWebhook
+          end
         end
       end
 

--- a/services/discourse_telegram_notifications/telegram-notifier.rb
+++ b/services/discourse_telegram_notifications/telegram-notifier.rb
@@ -25,7 +25,12 @@ module DiscourseTelegramNotifications
     end
 
     def self.deleteWebhook
-      return self.doRequest('deleteWebhook', {})
+      return false if SiteSetting.telegram_access_token.blank?
+
+      self.doRequest('deleteWebhook', {})
+    rescue StandardError => e
+      Rails.logger.error("Failed to delete Telegram webhook: #{e.class}: #{e.message}")
+      false
     end
 
     def self.editKeyboard(message)

--- a/services/discourse_telegram_notifications/telegram-notifier.rb
+++ b/services/discourse_telegram_notifications/telegram-notifier.rb
@@ -24,6 +24,10 @@ module DiscourseTelegramNotifications
       return self.doRequest('setWebhook', message)
     end
 
+    def self.deleteWebhook
+      return self.doRequest('deleteWebhook', {})
+    end
+
     def self.editKeyboard(message)
       return self.doRequest('editMessageReplyMarkup', message)
     end


### PR DESCRIPTION
**In short:** turning the plugin off did not tell Telegram to stop sending updates. This removes the webhook when the plugin is disabled.

### What was wrong
When a setting changes, a job runs. But the job stops early if the plugin is off:
```ruby
return if !SiteSetting.telegram_notifications_enabled?
```
So when an admin turns the plugin off, the webhook stays registered and Telegram keeps sending updates to the site.

### The fix
- Add `TelegramNotifier.deleteWebhook` (it calls Telegram's `deleteWebhook`).
- In the job: register the webhook when the plugin is on, and delete it when the plugin is off.

### How to verify manually
Enable the plugin, then disable it. Before: `getWebhookInfo` still shows the site URL. After: the webhook is cleared, and Telegram stops POSTing to `/telegram/hook/...`.

### Note for reviewers
This PR and #43 both edit `telegram-notifier.rb`, but different regions (a new `deleteWebhook` method here, `doRequest` in #43), so they should merge without conflict.

_Draft: checked with `ruby -c`._
