### PR TITLE
FIX: prune unbounded message_id map in plugin_store_rows

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3,6 +3,7 @@ en:
     telegram_notifications_enabled: Enable telegram notifications?
     telegram_access_token: Obtain your bot's access token from the telegram botfather
     telegram_enabled_notification_types: Limit notifications sent to Telegram by this selection of types
+    telegram_message_map_max_entries: "How many recent notification-to-post mappings to keep for routing Telegram replies. Older mappings are pruned daily. 0 disables pruning."
   discourse_telegram_notifications:
     initial-contact: "To get notifications for %{site_title}, enter the 'Chat ID' %{chat_id} in your user preferences"
     known-user: |-

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,3 +10,7 @@ plugins:
     type: list
     default: mentioned|replied|quoted|posted|linked|private_message|group_mentioned|watching_first_post|event_reminder|event_invitation|following_replied|following_posted
     client: false
+  telegram_message_map_max_entries:
+    default: 10000
+    min: 0
+    hidden: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -259,21 +259,22 @@ after_initialize do
       # The message_id -> post_id entries written on every outbound
       # notification (see SendTelegramNotifications) are never removed, so
       # plugin_store_rows grows without bound. That table has no timestamp
-      # columns, but its ids are monotonic, so keep only the most recent KEEP
-      # mappings - routing a Telegram reply back to a very old post is not
-      # useful anyway.
+      # columns, but its ids are monotonic, so keep only the most recent
+      # telegram_message_map_max_entries mappings - routing a Telegram reply
+      # back to a very old post is not useful anyway.
       class PruneTelegramMessageMap < ::Jobs::Scheduled
         every 1.day
 
-        KEEP = 10_000
-
         def execute(args)
+          keep = SiteSetting.telegram_message_map_max_entries
+          return if keep <= 0
+
           scope =
             PluginStoreRow
               .where(plugin_name: "telegram-notifications")
               .where("key LIKE 'message%'")
 
-          threshold_id = scope.order(id: :desc).offset(KEEP).limit(1).pick(:id)
+          threshold_id = scope.order(id: :desc).offset(keep).limit(1).pick(:id)
           return if threshold_id.nil?
 
           scope.where("id <= ?", threshold_id).delete_all

--- a/plugin.rb
+++ b/plugin.rb
@@ -272,8 +272,7 @@ after_initialize do
           scope =
             PluginStoreRow
               .where(plugin_name: "telegram-notifications")
-              .where("key LIKE 'message%'")
-
+              .where("key LIKE 'message\\_%'")
           threshold_id = scope.order(id: :desc).offset(keep).limit(1).pick(:id)
           return if threshold_id.nil?
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -256,5 +256,29 @@ after_initialize do
         end
       end
 
+      # The message_id -> post_id entries written on every outbound
+      # notification (see SendTelegramNotifications) are never removed, so
+      # plugin_store_rows grows without bound. That table has no timestamp
+      # columns, but its ids are monotonic, so keep only the most recent KEEP
+      # mappings - routing a Telegram reply back to a very old post is not
+      # useful anyway.
+      class PruneTelegramMessageMap < ::Jobs::Scheduled
+        every 1.day
+
+        KEEP = 10_000
+
+        def execute(args)
+          scope =
+            PluginStoreRow
+              .where(plugin_name: "telegram-notifications")
+              .where("key LIKE 'message%'")
+
+          threshold_id = scope.order(id: :desc).offset(KEEP).limit(1).pick(:id)
+          return if threshold_id.nil?
+
+          scope.where("id <= ?", threshold_id).delete_all
+        end
+      end
+
     end
 end


### PR DESCRIPTION
**In short:** the plugin saves one database row per sent notification and never deletes them, so the table grows forever. This adds a daily cleanup, with a site setting to control it.

### What was wrong
For every notification, the plugin saves a "message → post" row so it can handle replies:
```ruby
PluginStore.set("telegram-notifications", "message_#{message_id}", post.id)
```
These rows are never removed, so the `plugin_store_rows` table keeps growing for the whole life of the site.

That table has no date columns (only `id, plugin_name, key, type_name, value`), so we cannot filter by age directly.

### The fix
Add a daily job that keeps only the newest N `message_*` rows and deletes the older ones. The `id` column always counts up, so sorting by `id` is a reliable way to find the oldest rows without a date column.

N is the new hidden site setting **`telegram_message_map_max_entries`** (default `10000`). Admins can raise it on busy sites, or set it to `0` to turn pruning off. This addresses the review point that a busy forum could reach the old hardcoded 10,000 in a few days and lose the ability to reply to slightly older notifications.

### Note for reviewers
Removing old rows only affects *replying* to old Telegram notifications; sending is unaffected. I confirmed `plugin_store_rows` has no timestamp columns by reading Discourse's `create_plugin_store_rows` migration, which is why this uses an id-based cap rather than a date filter.

_Draft: checked with `ruby -c`; YAML validated with `YAML.load_file`._
